### PR TITLE
Add region to list of constructor arguments

### DIFF
--- a/src/main/java/com/amazonaws/custom/athena/jdbc/CustomIAMRoleAssumptionCredentialsProvider.java
+++ b/src/main/java/com/amazonaws/custom/athena/jdbc/CustomIAMRoleAssumptionCredentialsProvider.java
@@ -17,13 +17,13 @@ public class CustomIAMRoleAssumptionCredentialsProvider implements com.amazonaws
 	private AWSSecurityTokenService stsClient;
 	
 	//To use in JDBC: set aws_credentials_provider_class = "com.amazonaws.custom.athena.jdbc.CustomIAMRoleAssumptionCredentialsProvider"
-    // set AwsCredentialsProviderArguments = "<accessID>,<secretKey>,<roleArn>"
-	public CustomIAMRoleAssumptionCredentialsProvider(String accessId, String secretKey, String roleArn){
+    // set AwsCredentialsProviderArguments = "<accessID>,<secretKey>,<roleArn>,<region>"
+	public CustomIAMRoleAssumptionCredentialsProvider(String accessId, String secretKey, String roleArn, String region){
 		
 		this.credentials = new BasicAWSCredentials(accessId,secretKey);
 		this.roleArn = roleArn;
 		
-		stsClient = AWSSecurityTokenServiceClientBuilder.standard().withCredentials((com.amazonaws.auth.AWSCredentialsProvider) new AWSStaticCredentialsProvider(credentials)).build();
+		stsClient = AWSSecurityTokenServiceClientBuilder.standard().withCredentials((com.amazonaws.auth.AWSCredentialsProvider) new AWSStaticCredentialsProvider(credentials)).withRegion(region).build();
 		
 		refresh();
 		


### PR DESCRIPTION
Adresses issue https://github.com/aws-samples/aws-blog-athena-custom-jdbc-credentials/issues/1

*Issue #, if available: 1

*Description of changes:
Adding the possibility to provide a region in the AwsCredentialsProviderArguments property

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
