### PR TITLE
Require JDK >= 1.6, and specify encoding, to make Maven happy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<properties>
+		<maven.compiler.source>1.6</maven.compiler.source>
+		<maven.compiler.target>1.6</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.aws.labs</groupId>
 	<artifactId>athena-jdbc-custom-credentials-provider</artifactId>


### PR DESCRIPTION
Modified `pom.xml` to:
* Explicitly allow JDK > 1.5
* Explicitly specify that the source is `utf-8`

This makes `mvn package` happy enough to build with JDK 1.10 (my target); I've successfully used the built jar with Athena driver `2.0.7`, the EnvironmentVariablesCredentialProvider, and temporary AWS sessions to allow our IntelliJ DataGrip users to connect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
